### PR TITLE
Added pageUrl and alternateImages to Product

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.shopstyle</groupId>
   <artifactId>shopstyle-api-client</artifactId>
-  <version>0.1</version>
+  <version>0.1.1</version>
   <packaging>jar</packaging>
 
   <name>java-popsugar-shopping-api</name>

--- a/src/main/java/com/shopstyle/bo/Product.java
+++ b/src/main/java/com/shopstyle/bo/Product.java
@@ -24,7 +24,9 @@ public class Product
     private String description;
     private Brand brand;
     private String clickUrl;
+    private String pageUrl;
     private Image image;
+    private Image[] alternateImages;
     private ProductColor[] colors;
     private ProductSize[] sizes;
     private Category[] categories;
@@ -230,6 +232,16 @@ public class Product
     {
         this.clickUrl = clickUrl;
     }
+    
+    public String getPageUrl()
+    {
+        return pageUrl;
+    }
+
+    public void setPageUrl(String pageUrl)
+    {
+        this.pageUrl = pageUrl;
+    }
 
     public Image getImage()
     {
@@ -239,6 +251,16 @@ public class Product
     public void setImage(Image image)
     {
         this.image = image;
+    }
+    
+    public Image[] getAlternateImages()
+    {
+        return alternateImages;
+    }
+
+    public void setAlternateImages(Image[] alternateImages)
+    {
+        this.alternateImages = alternateImages;
     }
 
     public ProductColor[] getColors()


### PR DESCRIPTION
I’ve added 2 ‘Product’ fields that were missing in the Java client for the ShopStyle API, namely ‘pageUrl’ and ‘alternateImages’.